### PR TITLE
fix goroutine leaks problem when timeout really happens.

### DIFF
--- a/common/pool/pool.go
+++ b/common/pool/pool.go
@@ -64,7 +64,7 @@ func (this *SafeRpcConnPools) Call(addr, method string, args interface{}, resp i
 	rpcClient := conn.(RpcClient)
 	callTimeout := time.Duration(this.CallTimeout) * time.Millisecond
 
-	done := make(chan error)
+	done := make(chan error, 1)
 	go func() {
 		done <- rpcClient.Call(method, args, resp)
 	}()

--- a/modules/agent/g/rpc.go
+++ b/modules/agent/g/rpc.go
@@ -61,7 +61,7 @@ func (this *SingleConnRpcClient) Call(method string, args interface{}, reply int
 	this.insureConn()
 
 	timeout := time.Duration(50 * time.Second)
-	done := make(chan error)
+	done := make(chan error, 1)
 
 	go func() {
 		err := this.rpcClient.Call(method, args, reply)

--- a/modules/gateway/sender/conn_pool/conn_pool_rpc.go
+++ b/modules/gateway/sender/conn_pool/conn_pool_rpc.go
@@ -86,7 +86,7 @@ func (this *SafeRpcConnPools) Call(addr, method string, args interface{}, resp i
 	rpcClient := conn.(RpcClient)
 	callTimeout := time.Duration(this.CallTimeout) * time.Millisecond
 
-	done := make(chan error)
+	done := make(chan error, 1)
 	go func() {
 		done <- rpcClient.Call(method, args, resp)
 	}()

--- a/modules/transfer/sender/conn_pool/conn_pool_manager.go
+++ b/modules/transfer/sender/conn_pool/conn_pool_manager.go
@@ -83,7 +83,7 @@ func (this *SafeRpcConnPools) Call(addr, method string, args interface{}, resp i
 	rpcClient := conn.(RpcClient)
 	callTimeout := time.Duration(this.CallTimeout) * time.Millisecond
 
-	done := make(chan error)
+	done := make(chan error, 1)
 	go func() {
 		done <- rpcClient.Call(method, args, resp)
 	}()
@@ -216,7 +216,7 @@ func (this *TsdbConnPoolHelper) Send(data []byte) (err error) {
 
 	cli := conn.(TsdbClient).cli
 
-	done := make(chan error)
+	done := make(chan error, 1)
 	go func() {
 		_, err = cli.Write(data)
 		done <- err


### PR DESCRIPTION
Ref https://github.com/golang/go/wiki/Timeouts
Using channel to implement timeout, channel should have a buffer size of 1. Otherwise, the goroutine that has the send channel would never be destroyed.